### PR TITLE
Adapt to new Grappa urls for group memberships.

### DIFF
--- a/group/rest.go
+++ b/group/rest.go
@@ -275,7 +275,7 @@ func (m *manager) GetMembers(ctx context.Context, gid *grouppb.GroupId) ([]*user
 		return users, nil
 	}
 
-	url := fmt.Sprintf("%s/api/v1.0/Group/%s/memberidentities/precomputed?limit=10&field=upn&field=primaryAccountEmail&field=displayName&field=uid&field=gid&field=type&field=source", m.conf.APIBaseURL, gid.OpaqueId)
+	url := fmt.Sprintf("%s/api/v1.0/Group/%s/memberidentities/recursive?limit=10&field=upn&field=primaryAccountEmail&field=displayName&field=uid&field=gid&field=type&field=source", m.conf.APIBaseURL, gid.OpaqueId)
 
 	var r user.IdentitiesResponse
 	members := []*userpb.UserId{}

--- a/user/rest.go
+++ b/user/rest.go
@@ -345,7 +345,7 @@ func (m *manager) GetUserGroups(ctx context.Context, uid *userpb.UserId) ([]stri
 	}
 
 	// TODO (gdelmont): support pagination! we may have problems with users having more than 1000 groups
-	url := fmt.Sprintf("%s/api/v1.0/Identity/%s/groups?field=displayName&recursive=true", m.conf.APIBaseURL, uid.OpaqueId)
+	url := fmt.Sprintf("%s/api/v1.0/Identity/%s/groups/recursive?field=displayName", m.conf.APIBaseURL, uid.OpaqueId)
 
 	var r GroupsResponse
 	if err := m.apiTokenManager.SendAPIGetRequest(ctx, url, false, &r); err != nil {


### PR DESCRIPTION
See https://mattermost.web.cern.ch/it-dep/pl/ebjq4uz3wbbet8ato6fd1ca3qw