### PR TITLE
Changed logic to decide whether an account is Primary

### DIFF
--- a/user/rest.go
+++ b/user/rest.go
@@ -185,8 +185,10 @@ func (i *Identity) UserType() userpb.UserType {
 	case "Secondary":
 		return userpb.UserType_USER_TYPE_SECONDARY
 	case "Person":
-		if i.Source == "cern" && i.ActiveUser {
-			// this is a CERN account; incidentally, also i.UID > 0 qualifies for that
+		if i.Source == "cern" && i.UID > 0 {
+			// this is a CERN account; here we should check if i.ActiveUser = true,
+			// but users that have just left the Organization have ActiveUser = false,
+			// whereas users with UID = 0 are definitely non-primary.
 			return userpb.UserType_USER_TYPE_PRIMARY
 		}
 		return userpb.UserType_USER_TYPE_LIGHTWEIGHT // external user


### PR DESCRIPTION
This comes after having discovered that users that have just left the Organization have `active_user` = false, yet preserving their non-zero `uid`.

In order to allow access to their resources until the blocking via lifecycle management, we need to consider them "primary", otherwise their ACLs would be looked only as reva xattrs, not as EOS ACLs. Therefore, any `uid > 0` account is to be considered primary, regardless its `active_user` status.

Yet, we could use the `actve_user` flag as a "reminder" that the user has left, and take action in a different way. That's for a later change.