### PR TITLE
auth-api: fixed pagination following authz team recommendations

### DIFF
--- a/user/rest.go
+++ b/user/rest.go
@@ -168,9 +168,7 @@ type Identity struct {
 // when getting the list of users.
 type IdentitiesResponse struct {
 	Pagination struct {
-		Links struct {
-			Next *string `json:"next"`
-		} `json:"links"`
+		Next *string `json:"next"`
 	} `json:"pagination"`
 	Data []*Identity `json:"data"`
 }
@@ -212,10 +210,10 @@ func (m *manager) fetchAllUserAccounts(ctx context.Context) error {
 			}
 		}
 
-		if r.Pagination.Links.Next == nil {
+		if r.Pagination.Next == nil {
 			break
 		}
-		url = fmt.Sprintf("%s%s", m.conf.APIBaseURL, *r.Pagination.Links.Next)
+		url = fmt.Sprintf("%s%s", m.conf.APIBaseURL, *r.Pagination.Next)
 	}
 
 	return nil
@@ -335,9 +333,7 @@ type Group struct {
 // when getting the list of groups.
 type GroupsResponse struct {
 	Pagination struct {
-		Links struct {
-			Next *string `json:"next"`
-		} `json:"links"`
+		Next *string `json:"next"`
 	} `json:"pagination"`
 	Data []Group `json:"data"`
 }


### PR DESCRIPTION
Following our colleagues, we should use `pagination.next` as opposed to `pagination.links.next` - see https://gitlab.cern.ch/authzsvc/docs/authzsvc-docs/-/merge_requests/271