### PR TITLE
Fix missing escaping for '%' in fmt.Sprintf.

### DIFF
--- a/user/rest.go
+++ b/user/rest.go
@@ -196,7 +196,7 @@ func (i *Identity) UserType() userpb.UserType {
 }
 
 func (m *manager) fetchAllUserAccounts(ctx context.Context) error {
-	url := fmt.Sprintf("%s/api/v1.0/Identity?filter=unconfirmed%3Afalse&field=upn&field=primaryAccountEmail&field=displayName&field=uid&field=gid&field=type&field=source&field=activeUser", m.conf.APIBaseURL)
+	url := fmt.Sprintf("%s/api/v1.0/Identity?filter=unconfirmed%%3Afalse&field=upn&field=primaryAccountEmail&field=displayName&field=uid&field=gid&field=type&field=source&field=activeUser", m.conf.APIBaseURL)
 
 	for {
 		var r IdentitiesResponse


### PR DESCRIPTION
`%3A` is an invalid format ("unknown verb A"). As a result the generated string contains "%!A(MISSING)" instead of the expected "%3A".

See for example https://go.dev/play/p/eNRUAwujjk2