### PR TITLE
Added the option to mark a referenced share as orphan

### DIFF
--- a/share/sql/public_link.go
+++ b/share/sql/public_link.go
@@ -234,8 +234,7 @@ func (m *PublicShareMgr) MarkAsOrphaned(ctx context.Context, req *link.UpdatePub
 		return err
 	}
 
-	var res *gorm.DB
-	res = m.db.Model(&publiclink).
+	res := m.db.Model(&publiclink).
 		Where("id = ?", publiclink.Id).
 		Update("orphan", true)
 

--- a/share/sql/public_link.go
+++ b/share/sql/public_link.go
@@ -149,7 +149,7 @@ func (m *PublicShareMgr) CreatePublicShare(ctx context.Context, u *user.User, md
 }
 
 func (m *PublicShareMgr) UpdatePublicShare(ctx context.Context, u *user.User, req *link.UpdatePublicShareRequest, g *link.Grant) (*link.PublicShare, error) {
-	publiclink, err := m.getPublicLink(ctx, req.Ref)
+	publiclink, err := m.getEmptyPublicLink(ctx, req.Ref)
 	if err != nil {
 		return nil, err
 	}
@@ -215,7 +215,7 @@ func (m *PublicShareMgr) UpdatePublicShare(ctx context.Context, u *user.User, re
 }
 
 func (m *PublicShareMgr) MarkAsOrphaned(ctx context.Context, ref *link.PublicShareReference) error {
-	publicLink, err := m.getPublicLink(ctx, ref)
+	publicLink, err := m.getEmptyPublicLink(ctx, ref)
 	if err != nil {
 		return err
 	}
@@ -389,7 +389,7 @@ func (m *PublicShareMgr) GetPublicLink(ctx context.Context, ref *link.PublicShar
 }
 
 // Performs similarly to GetPublicLink but instead attempts to reduce the number of DB calls by creating a empty link containing only ID
-func (m *PublicShareMgr) getPublicLink(ctx context.Context, ref *link.PublicShareReference) (*model.PublicLink, error) {
+func (m *PublicShareMgr) getEmptyPublicLink(ctx context.Context, ref *link.PublicShareReference) (*model.PublicLink, error) {
 	var publiclink *model.PublicLink
 	var err error
 	if id := ref.GetId(); id != nil {

--- a/share/sql/share.go
+++ b/share/sql/share.go
@@ -391,7 +391,7 @@ func (m *ShareMgr) TransferShare(ctx context.Context, ref *collaboration.ShareRe
 	return nil
 }
 
-func (m *ShareMgr) MarkAsOrphaned(ctx context.Context, ref *collaboration.ShareReference) (error) {
+func (m *ShareMgr) MarkAsOrphaned(ctx context.Context, ref *collaboration.ShareReference) error {
 	share, err := m.getEmptyShareByRef(ctx, ref)
 	if err != nil {
 		return err
@@ -404,8 +404,10 @@ func (m *ShareMgr) MarkAsOrphaned(ctx context.Context, ref *collaboration.ShareR
 
 	return nil
 }
+
 // Move share moves a share to a new location, also updating its owner. It is the reponsibility of the caller to ensure that `newOwner`
 // corresponds to the owner of `newLocation`
+
 func (m *ShareMgr) MoveShare(ctx context.Context, ref *collaboration.ShareReference, newLocation *provider.ResourceId, newOwner string) error {
 	if newOwner == "" {
 		return errors.New("Must pass a non-nil owner")

--- a/share/sql/share.go
+++ b/share/sql/share.go
@@ -391,6 +391,19 @@ func (m *ShareMgr) TransferShare(ctx context.Context, ref *collaboration.ShareRe
 	return nil
 }
 
+func (m *ShareMgr) MarkAsOrphaned(ctx context.Context, ref *collaboration.ShareReference) (error) {
+	share, err := m.getEmptyShareByRef(ctx, ref)
+	if err != nil {
+		return err
+	}
+
+	res := m.db.Model(&share).Where("id = ?", share.Id).Update("orphan", true)
+	if res.Error != nil {
+		return res.Error
+	}
+
+	return nil
+}
 // Move share moves a share to a new location, also updating its owner. It is the reponsibility of the caller to ensure that `newOwner`
 // corresponds to the owner of `newLocation`
 func (m *ShareMgr) MoveShare(ctx context.Context, ref *collaboration.ShareReference, newLocation *provider.ResourceId, newOwner string) error {

--- a/share/sql/share.go
+++ b/share/sql/share.go
@@ -398,11 +398,7 @@ func (m *ShareMgr) MarkAsOrphaned(ctx context.Context, ref *collaboration.ShareR
 	}
 
 	res := m.db.Model(&share).Where("id = ?", share.Id).Update("orphan", true)
-	if res.Error != nil {
-		return res.Error
-	}
-
-	return nil
+	return res.Error
 }
 
 // Move share moves a share to a new location, also updating its owner. It is the reponsibility of the caller to ensure that `newOwner`


### PR DESCRIPTION
There was previously no functionality to simply update a share as orphaned that you only have a reference for. This PR fixes that by providing two small functions in the public links and shares files