### PR TITLE
return NotFound for requests to files outside of namespace

### DIFF
--- a/storage/eoswrapper/eoswrapper.go
+++ b/storage/eoswrapper/eoswrapper.go
@@ -24,6 +24,7 @@ import (
 	"errors"
 	"io"
 	"os"
+	"path"
 	"strings"
 	"text/template"
 
@@ -58,6 +59,8 @@ const (
 	requireAdmin  = 2
 	requireWriter = 1
 	requireReader = 0
+
+	blockedDirectory = ".blocked"
 )
 
 type wrapper struct {
@@ -117,6 +120,12 @@ func (w *wrapper) GetMD(ctx context.Context, ref *provider.Reference, mdKeys []s
 	res, err := w.FSWithListRegexSupport.GetMD(ctx, ref, mdKeys)
 	if err != nil {
 		return nil, err
+	}
+
+	// and that the space is not in a blocked state
+	blockedPath := path.Join(w.conf.Namespace, blockedDirectory)
+	if strings.HasPrefix(res.Path, blockedPath) {
+		return nil, errtypes.NotFound("file is in a blocked space")
 	}
 
 	// We need to extract the mount ID based on the mapping template.


### PR DESCRIPTION
`Stat`s to files that are not under the driver's configured namespace (such as those in the trashbin), or files that are in a blocked space, will now result in `NotFound`