### PR TITLE
Redis: implement sentinel model and make it configurable

### DIFF
--- a/group/cache.go
+++ b/group/cache.go
@@ -1,4 +1,4 @@
-// Copyright 2018-2023 CERN
+// Copyright 2018-2026 CERN
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,15 +19,15 @@
 package rest
 
 import (
+	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"strconv"
 	"strings"
-	"time"
 
 	grouppb "github.com/cs3org/go-cs3apis/cs3/identity/group/v1beta1"
 	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
+	"github.com/cs3org/reva/v3/pkg/appctx"
 	"github.com/gomodule/redigo/redis"
 )
 
@@ -40,116 +40,47 @@ const (
 	groupInternalIDPrefix = "internal:"
 )
 
-func initRedisPool(address, username, password string) *redis.Pool {
-	return &redis.Pool{
+func (m *manager) findCachedGroups(ctx context.Context, query string) ([]*grouppb.Group, error) {
+	query = fmt.Sprintf("%s*%s*", groupPrefix, strings.ReplaceAll(strings.ToLower(query), " ", "_"))
+	log := appctx.GetLogger(ctx)
 
-		MaxIdle:     50,
-		MaxActive:   1000,
-		IdleTimeout: 240 * time.Second,
-
-		Dial: func() (redis.Conn, error) {
-			var c redis.Conn
-			var err error
-			switch {
-			case username != "":
-				c, err = redis.Dial("tcp", address,
-					redis.DialUsername(username),
-					redis.DialPassword(password),
-				)
-			case password != "":
-				c, err = redis.Dial("tcp", address,
-					redis.DialPassword(password),
-				)
-			default:
-				c, err = redis.Dial("tcp", address)
-			}
-
-			if err != nil {
-				return nil, err
-			}
-			return c, err
-		},
-
-		TestOnBorrow: func(c redis.Conn, t time.Time) error {
-			_, err := c.Do("PING")
-			return err
-		},
-	}
-}
-
-func (m *manager) setVal(key, val string, expiration int) error {
-	conn := m.redisPool.Get()
-	defer conn.Close()
-	if conn != nil {
-		args := []interface{}{key, val}
-		if expiration != -1 {
-			args = append(args, "EX", expiration)
-		}
-		if _, err := conn.Do("SET", args...); err != nil {
-			return err
-		}
-		return nil
-	}
-	return errors.New("rest: unable to get connection from redis pool")
-}
-
-func (m *manager) getVal(key string) (string, error) {
-	conn := m.redisPool.Get()
-	defer conn.Close()
-	if conn != nil {
-		val, err := redis.String(conn.Do("GET", key))
-		if err != nil {
-			return "", err
-		}
-		return val, nil
-	}
-	return "", errors.New("rest: unable to get connection from redis pool")
-}
-
-func (m *manager) findCachedGroups(query string) ([]*grouppb.Group, error) {
-	conn := m.redisPool.Get()
-	defer conn.Close()
-	if conn != nil {
-		query = fmt.Sprintf("%s*%s*", groupPrefix, strings.ReplaceAll(strings.ToLower(query), " ", "_"))
+	raw, err := m.redisPools.DoWithReadFallback(ctx, func(conn redis.Conn) (interface{}, error) {
 		keys, err := redis.Strings(conn.Do("KEYS", query))
 		if err != nil {
 			return nil, err
 		}
-		var args []interface{}
-		for _, k := range keys {
-			args = append(args, k)
+		if len(keys) == 0 {
+			return []string{}, nil
 		}
-
-		if len(args) == 0 {
-			return []*grouppb.Group{}, nil
+		args := make([]interface{}, len(keys))
+		for i, k := range keys {
+			args[i] = k
 		}
-
-		// Fetch the groups for all these keys
-		groupStrings, err := redis.Strings(conn.Do("MGET", args...))
-		if err != nil {
-			return nil, err
-		}
-		groupMap := make(map[string]*grouppb.Group)
-		for _, group := range groupStrings {
-			g := grouppb.Group{}
-			if err = json.Unmarshal([]byte(group), &g); err == nil {
-				groupMap[g.Id.OpaqueId] = &g
-			}
-		}
-
-		var groups []*grouppb.Group
-		for _, g := range groupMap {
-			groups = append(groups, g)
-		}
-
-		return groups, nil
+		return redis.Strings(conn.Do("MGET", args...))
+	})
+	if err != nil {
+		return nil, err
 	}
 
-	return nil, errors.New("rest: unable to get connection from redis pool")
+	groupStrings := raw.([]string)
+	groupMap := make(map[string]*grouppb.Group)
+	for _, group := range groupStrings {
+		g := grouppb.Group{}
+		if err = json.Unmarshal([]byte(group), &g); err == nil {
+			groupMap[g.Id.OpaqueId] = &g
+		}
+	}
+
+	groups := make([]*grouppb.Group, 0, len(groupMap))
+	for _, g := range groupMap {
+		groups = append(groups, g)
+	}
+	log.Debug().Any("query", query).Int("results", len(groups)).Msg("rest: successfully found cached groups")
+	return groups, nil
 }
 
-func (m *manager) fetchCachedGroupDetails(gid *grouppb.GroupId) (*grouppb.Group, error) {
-	group, err := m.getVal(groupPrefix + idPrefix + gid.OpaqueId)
+func (m *manager) fetchCachedGroupDetails(ctx context.Context, gid *grouppb.GroupId) (*grouppb.Group, error) {
+	group, err := m.redisPools.GetVal(ctx, groupPrefix+idPrefix+gid.OpaqueId)
 	if err != nil {
 		return nil, err
 	}
@@ -166,25 +97,25 @@ func (m *manager) cacheGroupDetails(g *grouppb.Group) error {
 	if err != nil {
 		return err
 	}
-	if err = m.setVal(groupPrefix+idPrefix+strings.ToLower(g.Id.OpaqueId), string(encodedGroup), 5*m.conf.GroupFetchInterval); err != nil {
+	if err = m.redisPools.SetVal(groupPrefix+idPrefix+strings.ToLower(g.Id.OpaqueId), string(encodedGroup), 5*m.conf.GroupFetchInterval); err != nil {
 		return err
 	}
 
 	if g.GidNumber != 0 {
-		if err = m.setVal(groupPrefix+gidPrefix+strconv.FormatInt(g.GidNumber, 10), g.Id.OpaqueId, 5*m.conf.GroupFetchInterval); err != nil {
+		if err = m.redisPools.SetVal(groupPrefix+gidPrefix+strconv.FormatInt(g.GidNumber, 10), g.Id.OpaqueId, 5*m.conf.GroupFetchInterval); err != nil {
 			return err
 		}
 	}
 	if g.DisplayName != "" {
-		if err = m.setVal(groupPrefix+namePrefix+g.Id.OpaqueId+"_"+strings.ToLower(g.DisplayName), g.Id.OpaqueId, 5*m.conf.GroupFetchInterval); err != nil {
+		if err = m.redisPools.SetVal(groupPrefix+namePrefix+g.Id.OpaqueId+"_"+strings.ToLower(g.DisplayName), g.Id.OpaqueId, 5*m.conf.GroupFetchInterval); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func (m *manager) fetchCachedGroupByParam(field, claim string) (*grouppb.Group, error) {
-	group, err := m.getVal(groupPrefix + field + ":" + strings.ToLower(claim))
+func (m *manager) fetchCachedGroupByParam(ctx context.Context, field, claim string) (*grouppb.Group, error) {
+	group, err := m.redisPools.GetVal(ctx, groupPrefix+field+":"+strings.ToLower(claim))
 	if err != nil {
 		return nil, err
 	}
@@ -196,8 +127,8 @@ func (m *manager) fetchCachedGroupByParam(field, claim string) (*grouppb.Group, 
 	return &g, nil
 }
 
-func (m *manager) fetchCachedGroupMembers(gid *grouppb.GroupId) ([]*userpb.UserId, error) {
-	members, err := m.getVal(groupPrefix + groupMembersPrefix + strings.ToLower(gid.OpaqueId))
+func (m *manager) fetchCachedGroupMembers(ctx context.Context, gid *grouppb.GroupId) ([]*userpb.UserId, error) {
+	members, err := m.redisPools.GetVal(ctx, groupPrefix+groupMembersPrefix+strings.ToLower(gid.OpaqueId))
 	if err != nil {
 		return nil, err
 	}
@@ -213,5 +144,5 @@ func (m *manager) cacheGroupMembers(gid *grouppb.GroupId, members []*userpb.User
 	if err != nil {
 		return err
 	}
-	return m.setVal(groupPrefix+groupMembersPrefix+strings.ToLower(gid.OpaqueId), string(u), m.conf.GroupMembersCacheExpiration*60)
+	return m.redisPools.SetVal(groupPrefix+groupMembersPrefix+strings.ToLower(gid.OpaqueId), string(u), m.conf.GroupMembersCacheExpiration*60)
 }

--- a/group/rest.go
+++ b/group/rest.go
@@ -1,4 +1,4 @@
-// Copyright 2018-2023 CERN
+// Copyright 2018-2026 CERN
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ import (
 	"syscall"
 	"time"
 
+	redispools "github.com/cernbox/reva-plugins/redispools"
 	user "github.com/cernbox/reva-plugins/user"
 	grouppb "github.com/cs3org/go-cs3apis/cs3/identity/group/v1beta1"
 	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
@@ -36,7 +37,6 @@ import (
 	"github.com/cs3org/reva/v3/pkg/group"
 	"github.com/cs3org/reva/v3/pkg/utils/cfg"
 	"github.com/cs3org/reva/v3/pkg/utils/list"
-	"github.com/gomodule/redigo/redis"
 	"github.com/rs/zerolog/log"
 )
 
@@ -46,7 +46,7 @@ func init() {
 
 type manager struct {
 	conf            *config
-	redisPool       *redis.Pool
+	redisPools      *redispools.RedisPools
 	apiTokenManager *utils.APITokenManager
 }
 
@@ -60,10 +60,16 @@ func (manager) RevaPlugin() reva.PluginInfo {
 type config struct {
 	// The address at which the redis server is running
 	RedisAddress string `mapstructure:"redis_address" docs:"localhost:6379"`
+	// The address at which the redis sentinel is running (only used when redis_sentinel_mode is enabled)
+	RedisSentinelAddress string `mapstructure:"redis_sentinel_address" docs:""`
 	// The username for connecting to the redis server
 	RedisUsername string `mapstructure:"redis_username" docs:""`
 	// The password for connecting to the redis server
 	RedisPassword string `mapstructure:"redis_password" docs:""`
+	// The name of the master node in case Redis Sentinel mode is enabled
+	RedisMasterName string `mapstructure:"redis_master_name" docs:""`
+	// Whether to use Redis Sentinel mode
+	RedisSentinelMode bool `mapstructure:"redis_sentinel_mode" docs:""`
 	// The time in minutes for which the members of a group would be cached
 	GroupMembersCacheExpiration int `mapstructure:"group_members_cache_expiration" docs:"5"`
 	// The OIDC Provider
@@ -90,6 +96,9 @@ func (c *config) ApplyDefaults() {
 	if c.RedisAddress == "" {
 		c.RedisAddress = ":6379"
 	}
+	if c.RedisSentinelAddress == "" {
+		c.RedisSentinelAddress = c.RedisAddress
+	}
 	if c.APIBaseURL == "" {
 		c.APIBaseURL = "https://authorization-service-api-dev.web.cern.ch"
 	}
@@ -113,8 +122,13 @@ func New(ctx context.Context, m map[string]interface{}) (group.Manager, error) {
 	if err := cfg.Decode(m, &c); err != nil {
 		return nil, err
 	}
+	c.ApplyDefaults()
 
-	redisPool := initRedisPool(c.RedisAddress, c.RedisUsername, c.RedisPassword)
+	pools, err := redispools.NewRedisPoolsWithSentinelAddress(ctx, c.RedisAddress, c.RedisSentinelAddress, c.RedisUsername, c.RedisPassword, c.RedisSentinelMode, c.RedisMasterName)
+	if err != nil {
+		appctx.GetLogger(ctx).Error().Err(err).Msg("rest: failed to initialize redis pools")
+		pools = &redispools.RedisPools{}
+	}
 	apiTokenManager, err := utils.InitAPITokenManager(m)
 	if err != nil {
 		return nil, err
@@ -122,7 +136,7 @@ func New(ctx context.Context, m map[string]interface{}) (group.Manager, error) {
 
 	mgr := &manager{
 		conf:            &c,
-		redisPool:       redisPool,
+		redisPools:      pools,
 		apiTokenManager: apiTokenManager,
 	}
 	go mgr.fetchAllGroups(context.Background())
@@ -212,7 +226,7 @@ func (m *manager) parseAndCacheGroup(ctx context.Context, g *Group) (*grouppb.Gr
 }
 
 func (m *manager) GetGroup(ctx context.Context, gid *grouppb.GroupId, skipFetchingMembers bool) (*grouppb.Group, error) {
-	g, err := m.fetchCachedGroupDetails(gid)
+	g, err := m.fetchCachedGroupDetails(ctx, gid)
 	if err != nil {
 		return nil, err
 	}
@@ -233,7 +247,7 @@ func (m *manager) GetGroupByClaim(ctx context.Context, claim, value string, skip
 		return m.GetGroup(ctx, &grouppb.GroupId{OpaqueId: value}, skipFetchingMembers)
 	}
 
-	g, err := m.fetchCachedGroupByParam(claim, value)
+	g, err := m.fetchCachedGroupByParam(ctx, claim, value)
 	if err != nil {
 		return nil, err
 	}
@@ -264,11 +278,11 @@ func (m *manager) FindGroups(ctx context.Context, query string, skipFetchingMemb
 		}
 	}
 
-	return m.findCachedGroups(query)
+	return m.findCachedGroups(ctx, query)
 }
 
 func (m *manager) GetMembers(ctx context.Context, gid *grouppb.GroupId) ([]*userpb.UserId, error) {
-	users, err := m.fetchCachedGroupMembers(gid)
+	users, err := m.fetchCachedGroupMembers(ctx, gid)
 	if err == nil {
 		return users, nil
 	}

--- a/redispools/redispools.go
+++ b/redispools/redispools.go
@@ -1,0 +1,246 @@
+// Copyright 2018-2026 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package redispools
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/cs3org/reva/v3/pkg/appctx"
+	"github.com/gomodule/redigo/redis"
+)
+
+// RedisPools provides separate pools for read-local and write-master.
+//
+//   - Read pool always dials the configured address (local deployed instance).
+//   - Write pool dials the configured address if sentinel is disabled, otherwise
+//     discovers the current master via Sentinel and dials the master.
+//
+// Authentication:
+//   - dialRedis uses the provided username/password.
+//   - Sentinel is dialed using the same username/password, assuming Sentinel auth
+//     matches Redis auth in this deployment.
+type RedisPools struct {
+	Read  *redis.Pool
+	Write *redis.Pool
+}
+
+// SetVal sets a value in the redis pool
+func (p *RedisPools) SetVal(key, val string, expiration int) error {
+	conn := p.Write.Get()
+	defer conn.Close()
+	if conn != nil {
+		args := []interface{}{key, val}
+		if expiration != -1 {
+			args = append(args, "EX", expiration)
+		}
+		if _, err := conn.Do("SET", args...); err != nil {
+			return err
+		}
+		return nil
+	}
+	return errors.New("redispools: unable to get connection from redis pool")
+}
+
+// DoWithReadFallback runs fn on a connection from the read pool, falling back
+// to the write pool if the read pool is unavailable or fn returns an error.
+// redis.ErrNil is treated as a successful "not found" result and does not
+// trigger a fallback. The connection is released before fn is retried on the
+// write pool, so fn must not retain it.
+func (p *RedisPools) DoWithReadFallback(ctx context.Context, fn func(redis.Conn) (interface{}, error)) (interface{}, error) {
+	log := appctx.GetLogger(ctx)
+
+	conn := p.Read.Get()
+	if conn != nil && conn.Err() == nil {
+		val, err := fn(conn)
+		conn.Close()
+		if err == nil || err == redis.ErrNil {
+			return val, err
+		}
+		log.Debug().Err(err).Msg("redispools: read pool op failed, falling back to write pool")
+	} else if conn != nil {
+		log.Debug().Err(conn.Err()).Msg("redispools: read pool connection failed, falling back to write pool")
+		conn.Close()
+	} else {
+		log.Debug().Msg("redispools: read pool provided nil connection, falling back to write pool")
+	}
+
+	conn = p.Write.Get()
+	if conn == nil {
+		return nil, errors.New("redispools: unable to get connection from redis pool")
+	}
+	defer conn.Close()
+
+	return fn(conn)
+}
+
+// GetVal gets a value from the redis pool
+func (p *RedisPools) GetVal(ctx context.Context, key string) (string, error) {
+	val, err := p.DoWithReadFallback(ctx, func(c redis.Conn) (interface{}, error) {
+		return redis.String(c.Do("GET", key))
+	})
+	if err != nil {
+		return "", err
+	}
+	return val.(string), nil
+}
+
+func dialRedis(address, username, password string) (redis.Conn, error) {
+	var opts []redis.DialOption
+	if password != "" {
+		if username != "" {
+			opts = append(opts, redis.DialUsername(username))
+		}
+		opts = append(opts, redis.DialPassword(password))
+	}
+	return redis.Dial("tcp", address, opts...)
+}
+
+// NewRedisPoolsWithSentinelAddress allows specifying a separate Sentinel endpoint.
+//
+// - address: Redis data node address (used for reads, and for writes when sentinelMode=false)
+// - sentinelAddress: Sentinel address (used only for master discovery when sentinelMode=true)
+func NewRedisPoolsWithSentinelAddress(ctx context.Context, address, sentinelAddress, username, password string, sentinelMode bool, masterName string) (*RedisPools, error) {
+	log := appctx.GetLogger(ctx)
+
+	readPool := createRedisPool(func() (redis.Conn, error) {
+		// Prefer local instance.
+		c, err := dialRedis(address, username, password)
+		if err == nil {
+			return c, nil
+		}
+
+		// If local is down and sentinel mode is enabled, fall back to master.
+		if sentinelMode {
+			masterAddr, rerr := resolveSentinelMaster(sentinelAddress, username, password, masterName)
+			if rerr == nil && masterAddr != "" {
+				log.Debug().Any("masterAddr", masterAddr).Msg("read pool falling back to Sentinel-discovered master")
+				return dialRedis(masterAddr, username, password)
+			}
+		}
+
+		return nil, err
+	}, false, sentinelMode)
+
+	writePool := createRedisPool(func() (redis.Conn, error) {
+		var target string
+
+		if !sentinelMode {
+			target = address
+		} else {
+			masterAddr, err := resolveSentinelMaster(sentinelAddress, username, password, masterName)
+			log.Info().Any("masterAddr", masterAddr).Msg("rest: MasterAddresses resolved by Sentinel")
+			if err != nil {
+				// Do not fall back to `address` because it's typically a read-only replica,
+				// which would cause "READONLY" errors. Return the error directly to surface the root cause.
+				return nil, fmt.Errorf("resolveMaster failed: %w", err)
+			}
+			target = masterAddr
+		}
+
+		c, err := dialRedis(target, username, password)
+		if err != nil {
+			return nil, fmt.Errorf("dialRedis to %s failed: %w", target, err)
+		}
+
+		if sentinelMode {
+			// Specifically verify that the newly dialed node answers as "master".
+			// This prevents silent fallback errors or misconfigured Sentinels pointing us to a replica.
+			reply, err := redis.Values(c.Do("ROLE"))
+			if err == nil && len(reply) > 0 {
+				if role, err := redis.String(reply[0], nil); err == nil && role != "master" {
+					c.Close()
+					return nil, fmt.Errorf("write-pool dialed %s, but its role is %s (expected master). Check Redis/Sentinel configuration", target, role)
+				}
+			}
+		}
+
+		// Add a successful connection log for your debug
+		log.Info().Any("target", target).Msg("Successfully connected to write-pool target")
+
+		return c, nil
+	}, true, sentinelMode)
+
+	return &RedisPools{Read: readPool, Write: writePool}, nil
+}
+
+// createRedisPool creates a redis.Pool with the provided dial function and test on borrow logic.
+// including the optional check for master role if sentinel mode is enabled.
+func createRedisPool(dial func() (redis.Conn, error), isWritePool bool, sentinelMode bool) *redis.Pool {
+	return &redis.Pool{
+		MaxIdle:     50,
+		MaxActive:   1000,
+		IdleTimeout: 240 * time.Second,
+		Dial:        dial,
+		TestOnBorrow: func(c redis.Conn, t time.Time) error {
+			_, err := c.Do("PING")
+			if err != nil {
+				return err
+			}
+			if isWritePool && sentinelMode {
+				reply, err := redis.Values(c.Do("ROLE"))
+				if err == nil && len(reply) > 0 {
+					if role, err := redis.String(reply[0], nil); err == nil && role != "master" {
+						return errors.New("redis connection is not a master")
+					}
+				}
+			}
+			return err
+		},
+	}
+}
+
+// resolveSentinelMaster connects to the Sentinel and retrieves the current master address for the given master name.
+func resolveSentinelMaster(sentinelAddress, username, password, masterName string) (string, error) {
+	if masterName == "" {
+		return "", errors.New("utils: redis_sentinel_mode enabled but redis_master_name is empty")
+	}
+
+	sentinelConn, err := dialRedis(sentinelAddress, username, password)
+	if err != nil {
+		return "", err
+	}
+	defer sentinelConn.Close()
+
+	reply, err := redis.Values(sentinelConn.Do("SENTINEL", "get-master-addr-by-name", masterName))
+	if err != nil {
+		msg := strings.ToLower(err.Error())
+		if strings.Contains(msg, "unknown command") && strings.Contains(msg, "sentinel") {
+			return "", errors.New("utils: sentinelAddress is not a Sentinel endpoint")
+		}
+		return "", err
+	}
+	if len(reply) != 2 {
+		return "", errors.New("utils: invalid sentinel reply for get-master-addr-by-name")
+	}
+
+	host, err := redis.String(reply[0], nil)
+	if err != nil {
+		return "", err
+	}
+	port, err := redis.String(reply[1], nil)
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("%s:%s", host, port), nil
+}

--- a/user/cache.go
+++ b/user/cache.go
@@ -1,4 +1,4 @@
-// Copyright 2018-2023 CERN
+// Copyright 2018-2026 CERN
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,14 +19,14 @@
 package rest
 
 import (
+	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"strconv"
 	"strings"
-	"time"
 
 	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
+	"github.com/cs3org/reva/v3/pkg/appctx"
 	"github.com/cs3org/reva/v3/pkg/errtypes"
 	"github.com/gomodule/redigo/redis"
 )
@@ -40,91 +40,29 @@ const (
 	userGroupsPrefix = "groups:"
 )
 
-func initRedisPool(address, username, password string) *redis.Pool {
-	return &redis.Pool{
-
-		MaxIdle:     50,
-		MaxActive:   1000,
-		IdleTimeout: 240 * time.Second,
-
-		Dial: func() (redis.Conn, error) {
-			var opts []redis.DialOption
-			if username != "" {
-				opts = append(opts, redis.DialUsername(username))
-			}
-			if password != "" {
-				opts = append(opts, redis.DialPassword(password))
-			}
-
-			c, err := redis.Dial("tcp", address, opts...)
-			if err != nil {
-				return nil, err
-			}
-			return c, err
-		},
-
-		TestOnBorrow: func(c redis.Conn, t time.Time) error {
-			_, err := c.Do("PING")
-			return err
-		},
-	}
-}
-
-func (m *manager) setVal(key, val string, expiration int) error {
-	conn := m.redisPool.Get()
-	defer conn.Close()
-	if conn != nil {
-		args := []interface{}{key, val}
-		if expiration != -1 {
-			args = append(args, "EX", expiration)
-		}
-		if _, err := conn.Do("SET", args...); err != nil {
-			return err
-		}
-		return nil
-	}
-	return errors.New("rest: unable to get connection from redis pool")
-}
-
-func (m *manager) getVal(key string) (string, error) {
-	conn := m.redisPool.Get()
-	defer conn.Close()
-	if conn != nil {
-		val, err := redis.String(conn.Do("GET", key))
-		if err != nil {
-			return "", err
-		}
-		return val, nil
-	}
-	return "", errors.New("rest: unable to get connection from redis pool")
-}
-
-func (m *manager) findCachedUsers(query string) ([]*userpb.User, error) {
-	conn := m.redisPool.Get()
-	if conn == nil {
-		return nil, errors.New("rest: unable to get connection from redis pool")
-	}
-	defer conn.Close()
-
+func (m *manager) findCachedUsers(ctx context.Context, query string) ([]*userpb.User, error) {
 	query = fmt.Sprintf("%s*%s*", userPrefix, strings.ReplaceAll(strings.ToLower(query), " ", "_"))
-	keys, err := redis.Strings(conn.Do("KEYS", query))
+	log := appctx.GetLogger(ctx)
+
+	raw, err := m.redisPools.DoWithReadFallback(ctx, func(conn redis.Conn) (interface{}, error) {
+		keys, err := redis.Strings(conn.Do("KEYS", query))
+		if err != nil {
+			return nil, err
+		}
+		if len(keys) == 0 {
+			return []string{}, nil
+		}
+		args := make([]interface{}, len(keys))
+		for i, k := range keys {
+			args[i] = k
+		}
+		return redis.Strings(conn.Do("MGET", args...))
+	})
 	if err != nil {
 		return nil, err
 	}
-	var args []interface{}
-	for _, k := range keys {
-		args = append(args, k)
-	}
 
-	if len(args) == 0 {
-		return []*userpb.User{}, nil
-	}
-
-	// Fetch the users for all these keys
-	userStrings, err := redis.Strings(conn.Do("MGET", args...))
-	if err != nil {
-		return nil, err
-	}
+	userStrings := raw.([]string)
 	userMap := make(map[string]*userpb.User)
 	for _, user := range userStrings {
 		u := userpb.User{}
@@ -133,17 +71,16 @@ func (m *manager) findCachedUsers(query string) ([]*userpb.User, error) {
 		}
 	}
 
-	var users []*userpb.User
+	users := make([]*userpb.User, 0, len(userMap))
 	for _, u := range userMap {
 		users = append(users, u)
 	}
-
+	log.Debug().Any("query", query).Int("results", len(users)).Msg("rest: successfully found cached users")
 	return users, nil
-
 }
 
-func (m *manager) fetchCachedUserDetails(uid *userpb.UserId) (*userpb.User, error) {
-	user, err := m.getVal(userPrefix + usernamePrefix + strings.ToLower(uid.OpaqueId))
+func (m *manager) fetchCachedUserDetails(ctx context.Context, uid *userpb.UserId) (*userpb.User, error) {
+	user, err := m.redisPools.GetVal(ctx, userPrefix+usernamePrefix+strings.ToLower(uid.OpaqueId))
 	if err != nil {
 		return nil, err
 	}
@@ -160,36 +97,36 @@ func (m *manager) cacheUserDetails(u *userpb.User) error {
 	if err != nil {
 		return err
 	}
-	if err = m.setVal(userPrefix+usernamePrefix+strings.ToLower(u.Id.OpaqueId), string(encodedUser), 5*m.conf.UserFetchInterval); err != nil {
+	if err = m.redisPools.SetVal(userPrefix+usernamePrefix+strings.ToLower(u.Id.OpaqueId), string(encodedUser), 5*m.conf.UserFetchInterval); err != nil {
 		return err
 	}
 
 	if u.Mail != "" {
-		if err = m.setVal(userPrefix+mailPrefix+strings.ToLower(u.Mail), string(encodedUser), 5*m.conf.UserFetchInterval); err != nil {
+		if err = m.redisPools.SetVal(userPrefix+mailPrefix+strings.ToLower(u.Mail), string(encodedUser), 5*m.conf.UserFetchInterval); err != nil {
 			return err
 		}
 	}
 	if u.DisplayName != "" {
-		if err = m.setVal(userPrefix+namePrefix+u.Id.OpaqueId+"_"+strings.ReplaceAll(strings.ToLower(u.DisplayName), " ", "_"), string(encodedUser), 5*m.conf.UserFetchInterval); err != nil {
+		if err = m.redisPools.SetVal(userPrefix+namePrefix+u.Id.OpaqueId+"_"+strings.ReplaceAll(strings.ToLower(u.DisplayName), " ", "_"), string(encodedUser), 5*m.conf.UserFetchInterval); err != nil {
 			return err
 		}
 	}
 	if u.UidNumber != 0 {
-		if err = m.setVal(userPrefix+uidPrefix+strconv.FormatInt(u.UidNumber, 10), string(encodedUser), 5*m.conf.UserFetchInterval); err != nil {
+		if err = m.redisPools.SetVal(userPrefix+uidPrefix+strconv.FormatInt(u.UidNumber, 10), string(encodedUser), 5*m.conf.UserFetchInterval); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func (m *manager) fetchCachedUserByParam(field, claim string) (*userpb.User, error) {
+func (m *manager) fetchCachedUserByParam(ctx context.Context, field, claim string) (*userpb.User, error) {
 	// We do not want to support linked external accounts
 	// These can be identified by having username equal to a CERN email
 	if field == "username" && strings.HasSuffix(claim, "@cern.ch") {
 		return nil, errtypes.Conflict("linked external accounts are not supported")
 	}
 
-	user, err := m.getVal(userPrefix + field + ":" + strings.ToLower(claim))
+	user, err := m.redisPools.GetVal(ctx, userPrefix+field+":"+strings.ToLower(claim))
 	if err != nil {
 		return nil, err
 	}
@@ -201,8 +138,8 @@ func (m *manager) fetchCachedUserByParam(field, claim string) (*userpb.User, err
 	return &u, nil
 }
 
-func (m *manager) fetchCachedUserGroups(uid *userpb.UserId) ([]string, error) {
-	groups, err := m.getVal(userPrefix + userGroupsPrefix + strings.ToLower(uid.OpaqueId))
+func (m *manager) fetchCachedUserGroups(ctx context.Context, uid *userpb.UserId) ([]string, error) {
+	groups, err := m.redisPools.GetVal(ctx, userPrefix+userGroupsPrefix+strings.ToLower(uid.OpaqueId))
 	if err != nil {
 		return nil, err
 	}
@@ -218,5 +155,5 @@ func (m *manager) cacheUserGroups(uid *userpb.UserId, groups []string) error {
 	if err != nil {
 		return err
 	}
-	return m.setVal(userPrefix+userGroupsPrefix+strings.ToLower(uid.OpaqueId), string(g), m.conf.UserGroupsCacheExpiration*60)
+	return m.redisPools.SetVal(userPrefix+userGroupsPrefix+strings.ToLower(uid.OpaqueId), string(g), m.conf.UserGroupsCacheExpiration*60)
 }

--- a/user/rest.go
+++ b/user/rest.go
@@ -1,4 +1,4 @@
-// Copyright 2018-2023 CERN
+// Copyright 2018-2026 CERN
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import (
 	"syscall"
 	"time"
 
+	redispools "github.com/cernbox/reva-plugins/redispools"
 	"github.com/cernbox/reva-plugins/utils"
 	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	"github.com/cs3org/reva/v3"
@@ -36,7 +37,6 @@ import (
 	"github.com/cs3org/reva/v3/pkg/user"
 	"github.com/cs3org/reva/v3/pkg/utils/cfg"
 	"github.com/cs3org/reva/v3/pkg/utils/list"
-	"github.com/gomodule/redigo/redis"
 )
 
 func init() {
@@ -45,7 +45,7 @@ func init() {
 
 type manager struct {
 	conf            *config
-	redisPool       *redis.Pool
+	redisPools      *redispools.RedisPools
 	apiTokenManager *revautils.APITokenManager
 }
 
@@ -59,10 +59,16 @@ func (manager) RevaPlugin() reva.PluginInfo {
 type config struct {
 	// The address at which the redis server is running
 	RedisAddress string `mapstructure:"redis_address" docs:"localhost:6379"`
+	// The address at which the redis sentinel is running (only used when redis_sentinel_mode is enabled)
+	RedisSentinelAddress string `mapstructure:"redis_sentinel_address" docs:""`
 	// The username for connecting to the redis server
 	RedisUsername string `mapstructure:"redis_username" docs:""`
 	// The password for connecting to the redis server
 	RedisPassword string `mapstructure:"redis_password" docs:""`
+	// The name of the master node in case Redis Sentinel mode is enabled
+	RedisMasterName string `mapstructure:"redis_master_name" docs:""`
+	// Whether to use Redis Sentinel mode
+	RedisSentinelMode bool `mapstructure:"redis_sentinel_mode" docs:""`
 	// The time in minutes for which the groups to which a user belongs would be cached
 	UserGroupsCacheExpiration int `mapstructure:"user_groups_cache_expiration" docs:"5"`
 	// The OIDC Provider
@@ -89,6 +95,10 @@ func (c *config) ApplyDefaults() {
 	if c.RedisAddress == "" {
 		c.RedisAddress = ":6379"
 	}
+	if c.RedisSentinelAddress == "" {
+		// Backwards compatible default: if not set, assume sentinel is reachable at RedisAddress.
+		c.RedisSentinelAddress = c.RedisAddress
+	}
 	if c.APIBaseURL == "" {
 		c.APIBaseURL = "https://authorization-service-api-dev.web.cern.ch"
 	}
@@ -109,25 +119,32 @@ func (c *config) ApplyDefaults() {
 // New returns a user manager implementation that makes calls to the GRAPPA API.
 func New(ctx context.Context, m map[string]interface{}) (user.Manager, error) {
 	mgr := &manager{}
-	err := mgr.Configure(m)
+	err := mgr.Configure(m, ctx)
 	if err != nil {
 		return nil, err
 	}
 	return mgr, err
 }
 
-func (m *manager) Configure(ml map[string]interface{}) error {
+func (m *manager) Configure(ml map[string]interface{}, ctx context.Context) error {
 	var c config
 	if err := cfg.Decode(ml, &c); err != nil {
 		return err
 	}
-	redisPool := initRedisPool(c.RedisAddress, c.RedisUsername, c.RedisPassword)
+	c.ApplyDefaults()
+
+	pools, err := redispools.NewRedisPoolsWithSentinelAddress(ctx, c.RedisAddress, c.RedisSentinelAddress, c.RedisUsername, c.RedisPassword, c.RedisSentinelMode, c.RedisMasterName)
+	if err != nil {
+		appctx.GetLogger(ctx).Error().Err(err).Msg("rest: failed to initialize redis pools")
+		pools = &redispools.RedisPools{}
+	}
+
 	apiTokenManager, err := revautils.InitAPITokenManager(ml)
 	if err != nil {
 		return err
 	}
 	m.conf = &c
-	m.redisPool = redisPool
+	m.redisPools = pools
 	m.apiTokenManager = apiTokenManager
 
 	// Since we're starting a subroutine which would take some time to execute,
@@ -138,7 +155,11 @@ func (m *manager) Configure(ml map[string]interface{}) error {
 }
 
 func (m *manager) fetchAllUsers(ctx context.Context) {
-	_ = m.fetchAllUserAccounts(ctx)
+	log := appctx.GetLogger(ctx)
+	if err := m.fetchAllUserAccounts(ctx); err != nil {
+		log.Error().Err(err).Msg("rest: failed to fetch user accounts on startup")
+	}
+
 	ticker := time.NewTicker(time.Duration(m.conf.UserFetchInterval) * time.Second)
 	work := make(chan os.Signal, 1)
 	signal.Notify(work, syscall.SIGHUP, syscall.SIGINT, syscall.SIGQUIT)
@@ -148,7 +169,9 @@ func (m *manager) fetchAllUsers(ctx context.Context) {
 		case <-work:
 			return
 		case <-ticker.C:
-			_ = m.fetchAllUserAccounts(ctx)
+			if err := m.fetchAllUserAccounts(ctx); err != nil {
+				log.Error().Err(err).Msg("rest: failed to fetch user accounts periodically")
+			}
 		}
 	}
 }
@@ -275,7 +298,7 @@ func (m *manager) fetchExternalIdentities(ctx context.Context, email string) ([]
 }
 
 func (m *manager) GetUser(ctx context.Context, uid *userpb.UserId, skipFetchingGroups bool) (*userpb.User, error) {
-	u, err := m.fetchCachedUserDetails(uid)
+	u, err := m.fetchCachedUserDetails(ctx, uid)
 	if err != nil {
 		return nil, err
 	}
@@ -292,7 +315,7 @@ func (m *manager) GetUser(ctx context.Context, uid *userpb.UserId, skipFetchingG
 }
 
 func (m *manager) GetUserByClaim(ctx context.Context, claim, value string, skipFetchingGroups bool) (*userpb.User, error) {
-	u, err := m.fetchCachedUserByParam(claim, value)
+	u, err := m.fetchCachedUserByParam(ctx, claim, value)
 	if err != nil {
 		return nil, err
 	}
@@ -322,7 +345,7 @@ func (m *manager) FindUsers(ctx context.Context, query string, filters []*userpb
 		namespace, query = parts[0], parts[1]
 	}
 
-	users, err := m.findCachedUsers(query)
+	users, err := m.findCachedUsers(ctx, query)
 	if err != nil {
 		return nil, err
 	}
@@ -390,7 +413,7 @@ type GroupsResponse struct {
 }
 
 func (m *manager) GetUserGroups(ctx context.Context, uid *userpb.UserId) ([]string, error) {
-	cachedGroups, err := m.fetchCachedUserGroups(uid)
+	cachedGroups, err := m.fetchCachedUserGroups(ctx, uid)
 	if err == nil {
 		return cachedGroups, nil
 	}
@@ -426,7 +449,11 @@ func (m *manager) GetUserGroups(ctx context.Context, uid *userpb.UserId) ([]stri
 
 	if err := m.cacheUserGroups(uid, groups.Values()); err != nil {
 		log := appctx.GetLogger(ctx)
-		log.Error().Err(err).Msg("rest: error caching user groups")
+		if m.conf.RedisSentinelMode {
+			log.Error().Str("sentinelAddress", m.conf.RedisSentinelAddress).Msg("rest: error caching user groups in Sentinel mode, check Sentinel connectivity and master discovery")
+		} else {
+			log.Error().Str("redisAddress", m.conf.RedisAddress).Msg("rest: error caching user groups, check Redis connectivity")
+		}
 	}
 
 	return groups.Values(), nil


### PR DESCRIPTION
This PR adds the configurable option of having Redis in sentinel mode

- If this is enabled we have to discover the redis master
- Added two configurable options RedisSentinelMode (enables the discovery) and RedisMasterName (name of the master).